### PR TITLE
Increase side padding on mobile to reduce cramped feeling

### DIFF
--- a/index.html
+++ b/index.html
@@ -900,7 +900,7 @@
     
     @media (max-width: 768px) {
       .hero {
-        padding: 6rem 1rem 3rem;
+        padding: 6rem 1.5rem 3rem;
       }
 
       .hero h1 {
@@ -930,7 +930,7 @@
       }
 
       .library-callout {
-        padding: 3rem 1rem;
+        padding: 3rem 1.5rem;
       }
 
       .perfect-for .section-subtitle,
@@ -972,13 +972,13 @@
       }
 
       nav .container {
-        padding: 0.75rem 1rem;
+        padding: 0.75rem 1.25rem;
       }
     }
 
     @media (max-width: 480px) {
       .hero {
-        padding: 5.5rem 0.75rem 2rem;
+        padding: 5.5rem 1.25rem 2rem;
       }
 
       .hero h1 {
@@ -990,11 +990,11 @@
       }
 
       .how-it-works, .calculator, .features, .cta, .perfect-for, .comparison, .faq {
-        padding: 3rem 0.75rem;
+        padding: 3rem 1.25rem;
       }
 
       .library-callout {
-        padding: 2.5rem 0.75rem;
+        padding: 2.5rem 1.25rem;
       }
 
       .how-it-works h2, .features h2, .cta h2, .perfect-for h2, .comparison h2, .faq h2 {
@@ -1036,7 +1036,7 @@
       }
 
       footer {
-        padding: 2rem 0.75rem;
+        padding: 2rem 1.25rem;
       }
     }
   </style>


### PR DESCRIPTION
- 768px: hero and library-callout padding from 1rem to 1.5rem sides
- 480px: all sections from 0.75rem to 1.25rem sides (hero, how-it-works, calculator, features, cta, perfect-for, comparison, faq, library-callout, footer, nav)

https://claude.ai/code/session_01HPTRjZTNRWH4axUJLZcmqf